### PR TITLE
Catch errors in asynchronous controllers

### DIFF
--- a/src/asyncCatch.ts
+++ b/src/asyncCatch.ts
@@ -1,0 +1,31 @@
+/**
+ * Handle exceptions thrown in async functions.
+ * @packageDocumentation
+ */
+
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * A route controller function.
+ */
+type Controller = (
+  req: Request,
+  res: Response,
+  next?: NextFunction
+) => Promise<void>;
+
+/**
+ * Wrap an asynchronous route controller in a try/catch block.
+ *
+ * @param route The route controller.
+ * @returns The wrapped route controller.
+ */
+export default function wrapRoute(route: Controller): Controller {
+  return async (req: Request, res: Response, next?: NextFunction) => {
+    try {
+      await route(req, res, next);
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/src/routes/image.ts
+++ b/src/routes/image.ts
@@ -5,6 +5,7 @@
 
 import { Router } from "express";
 import { renderError } from "./util";
+import wrapRoute from "../asyncCatch";
 import { UserService, PostService } from "../services";
 import proxy from "../proxy";
 
@@ -14,13 +15,40 @@ import proxy from "../proxy";
 export const imageRouter = Router();
 
 // Get a user's image
-imageRouter.get("/user/:userID", async (req, res, next) => {
-  const userExists = await UserService.userExists(req.params.userID);
+imageRouter.get(
+  "/user/:userID",
+  wrapRoute(async (req, res, next) => {
+    const userExists = await UserService.userExists(req.params.userID);
 
-  if (userExists) {
-    const image = await UserService.getUserImage(req.params.userID);
+    if (userExists) {
+      const image = await UserService.getUserImage(req.params.userID);
 
-    if (image) {
+      if (image) {
+        res.write(image.data, async (err) => {
+          if (err) {
+            await renderError(err, req, res);
+          }
+          res.end();
+        });
+      } else {
+        const host = req.protocol + "://" + req.get("host");
+        proxy(res, host + "/img/compass_b.png");
+      }
+    } else {
+      next(); // 404
+    }
+  })
+);
+
+// Get a post's image
+imageRouter.get(
+  "/post/:postID",
+  wrapRoute(async (req, res, next) => {
+    const postExists = await PostService.postExists(req.params.postID);
+
+    if (postExists) {
+      const image = await PostService.getPostImage(req.params.postID);
+
       res.write(image.data, async (err) => {
         if (err) {
           await renderError(err, req, res);
@@ -28,28 +56,7 @@ imageRouter.get("/user/:userID", async (req, res, next) => {
         res.end();
       });
     } else {
-      const host = req.protocol + "://" + req.get("host");
-      proxy(res, host + "/img/compass_b.png");
+      next(); // 404
     }
-  } else {
-    next(); // 404
-  }
-});
-
-// Get a post's image
-imageRouter.get("/post/:postID", async (req, res, next) => {
-  const postExists = await PostService.postExists(req.params.postID);
-
-  if (postExists) {
-    const image = await PostService.getPostImage(req.params.postID);
-
-    res.write(image.data, async (err) => {
-      if (err) {
-        await renderError(err, req, res);
-      }
-      res.end();
-    });
-  } else {
-    next(); // 404
-  }
-});
+  })
+);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@
 
 import { Router } from "express";
 import { renderPage } from "./util";
+import wrapRoute from "../asyncCatch";
 
 /**
  * The index router.
@@ -12,6 +13,9 @@ import { renderPage } from "./util";
 export const indexRouter = Router();
 
 // Index page
-indexRouter.get("/", async (req, res) => {
-  await renderPage(req, res, "index");
-});
+indexRouter.get(
+  "/",
+  wrapRoute(async (req, res) => {
+    await renderPage(req, res, "index");
+  })
+);

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -5,6 +5,7 @@
 
 import { Router } from "express";
 import { renderPage, setSessionID } from "./util";
+import wrapRoute from "../asyncCatch";
 import { UserService, SessionService } from "../services";
 
 /**
@@ -13,33 +14,39 @@ import { UserService, SessionService } from "../services";
 export const loginRouter = Router();
 
 // Login page
-loginRouter.get("/", async (req, res) => {
-  await renderPage(req, res, "login", { title: "Login" });
-});
+loginRouter.get(
+  "/",
+  wrapRoute(async (req, res) => {
+    await renderPage(req, res, "login", { title: "Login" });
+  })
+);
 
 // Login event
-loginRouter.post("/", async (req, res) => {
-  const email = req.body.email;
-  const password = req.body.password;
+loginRouter.post(
+  "/",
+  wrapRoute(async (req, res) => {
+    const email = req.body.email;
+    const password = req.body.password;
 
-  const validLogin = await UserService.login(email, password);
+    const validLogin = await UserService.login(email, password);
 
-  if (validLogin) {
-    const user = await UserService.getUserByEmail(email);
-    const sessionID = await SessionService.createSession(user.id);
-    setSessionID(res, sessionID);
+    if (validLogin) {
+      const user = await UserService.getUserByEmail(email);
+      const sessionID = await SessionService.createSession(user.id);
+      setSessionID(res, sessionID);
 
-    const after = req.query.after as string;
+      const after = req.query.after as string;
 
-    if (after) {
-      res.redirect(after);
+      if (after) {
+        res.redirect(after);
+      } else {
+        res.redirect("/");
+      }
     } else {
-      res.redirect("/");
+      await renderPage(req, res, "login", {
+        title: "Login",
+        error: "Invalid login",
+      });
     }
-  } else {
-    await renderPage(req, res, "login", {
-      title: "Login",
-      error: "Invalid login",
-    });
-  }
-});
+  })
+);

--- a/src/routes/logout.ts
+++ b/src/routes/logout.ts
@@ -5,6 +5,7 @@
 
 import { Router } from "express";
 import { getSessionID, deleteSessionID } from "./util";
+import wrapRoute from "../asyncCatch";
 import { SessionService } from "../services";
 
 /**
@@ -13,19 +14,22 @@ import { SessionService } from "../services";
 export const logoutRouter = Router();
 
 // Logout event
-logoutRouter.get("/", async (req, res) => {
-  const sessionID = getSessionID(req);
+logoutRouter.get(
+  "/",
+  wrapRoute(async (req, res) => {
+    const sessionID = getSessionID(req);
 
-  if (sessionID) {
-    deleteSessionID(res);
-    await SessionService.deleteSession(sessionID);
-  }
+    if (sessionID) {
+      deleteSessionID(res);
+      await SessionService.deleteSession(sessionID);
+    }
 
-  const after = req.query.after as string;
+    const after = req.query.after as string;
 
-  if (after) {
-    res.redirect(after);
-  } else {
-    res.redirect("/login");
-  }
-});
+    if (after) {
+      res.redirect(after);
+    } else {
+      res.redirect("/login");
+    }
+  })
+);

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -5,6 +5,7 @@
 
 import { Router } from "express";
 import { renderPage } from "./util";
+import wrapRoute from "../asyncCatch";
 import { PostService, UserStatusService } from "../services";
 
 /**
@@ -13,19 +14,24 @@ import { PostService, UserStatusService } from "../services";
 export const postRouter = Router();
 
 // Post page
-postRouter.get("/:postID", async (req, res) => {
-  const post = await PostService.getPost(req.params.postID);
-  const user = await PostService.getPostUser(req.params.postID);
-  const userStatusName = await UserStatusService.getStatusName(user.statusID);
+postRouter.get(
+  "/:postID",
+  wrapRoute(async (req, res) => {
+    const post = await PostService.getPost(req.params.postID);
+    const user = await PostService.getPostUser(req.params.postID);
+    const userStatusName = await UserStatusService.getStatusName(
+      user.statusID
+    );
 
-  await renderPage(req, res, "post", {
-    location: post.location,
-    firstname: user.firstname,
-    lastname: user.lastname,
-    status: userStatusName,
-    program: post.program,
-    createTime: post.createTime,
-    threeWords: post.threeWords,
-    content: post.content,
-  });
-});
+    await renderPage(req, res, "post", {
+      location: post.location,
+      firstname: user.firstname,
+      lastname: user.lastname,
+      status: userStatusName,
+      program: post.program,
+      createTime: post.createTime,
+      threeWords: post.threeWords,
+      content: post.content,
+    });
+  })
+);


### PR DESCRIPTION
The vast majority of our controllers are asynchronous. One of the downsides of this is that when an error is thrown from within one of the controllers, it is not handled properly, and the 500 page is not rendered.

This PR fixes the issue by wrapping each controller using a function that does a try/catch (as opposed to manually placing a try/catch block inside each and every controller).

closes #44 
