### PR TITLE
Stop async session pruning in tests

### DIFF
--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -28,7 +28,7 @@ jest.setTimeout(10000);
 beforeAll(
   async () =>
     new Promise((resolve) => {
-      initDB().then(resolve);
+      initDB(false).then(resolve);
     })
 );
 


### PR DESCRIPTION
Upon database initialization, asynchronous operations attempting to prune active user sessions would begin. This was causing problems while running tests, as the tests would not fully complete since there were still asynchronous operations running in the background. Now, these session pruning operations will not run during testing.