### PR TITLE
PostImage table

### DIFF
--- a/src/dbinit.ts
+++ b/src/dbinit.ts
@@ -125,7 +125,6 @@ export default async function initDB(prune: boolean = true): Promise<void> {
       id             CHAR(4)       NOT NULL,
       userID         CHAR(4)       NOT NULL,
       content        VARCHAR(750)  NOT NULL,
-      imageID        CHAR(4)       NOT NULL,
       location       VARCHAR(255)  NOT NULL,
       locationTypeID INT           NOT NULL,
       program        VARCHAR(255)  NOT NULL,
@@ -140,9 +139,6 @@ export default async function initDB(prune: boolean = true): Promise<void> {
       FOREIGN KEY (userID)
         REFERENCES User (id),
 
-      FOREIGN KEY (imageID)
-        REFERENCES Image (id),
-      
       FOREIGN KEY (locationTypeID)
         REFERENCES LocationType (id),
 

--- a/src/dbinit.ts
+++ b/src/dbinit.ts
@@ -150,6 +150,18 @@ export default async function initDB(prune: boolean = true): Promise<void> {
         REFERENCES Rating (id)
     );
   `;
+  const postImageTable = `
+    CREATE TABLE IF NOT EXISTS PostImage (
+      postID  CHAR(4) NOT NULL,
+      imageID CHAR(4) NOT NULL,
+
+      FOREIGN KEY (postID)
+        REFERENCES Post (id),
+
+      FOREIGN KEY (imageID)
+        REFERENCES Image (id)
+    );
+  `;
   const sessionTable = `
     CREATE TABLE IF NOT EXISTS Session (
       id         CHAR(16)     NOT NULL,
@@ -196,6 +208,7 @@ export default async function initDB(prune: boolean = true): Promise<void> {
     ratingTable,
     userTable,
     postTable,
+    postImageTable,
     sessionTable,
     verifyTable,
     passwordResetTable,

--- a/src/dbinit.ts
+++ b/src/dbinit.ts
@@ -148,8 +148,11 @@ export default async function initDB(prune: boolean = true): Promise<void> {
   `;
   const postImageTable = `
     CREATE TABLE IF NOT EXISTS PostImage (
-      postID  CHAR(4) NOT NULL,
-      imageID CHAR(4) NOT NULL,
+      id      INT UNSIGNED NOT NULL AUTO_INCREMENT,
+      postID  CHAR(4)      NOT NULL,
+      imageID CHAR(4)      NOT NULL,
+
+      PRIMARY KEY (id),
 
       FOREIGN KEY (postID)
         REFERENCES Post (id),

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -7,6 +7,7 @@ import mainDB, { getTime, newUniqueID } from "./util";
 import { Image, ImageService } from "./image";
 import { Rating, RatingParams, RatingService } from "./rating";
 import { User, UserService } from "./user";
+import { PostImageService } from "./postImage";
 
 /**
  * Post architecture.
@@ -15,7 +16,6 @@ export interface Post {
   id: string;
   userID: string;
   content: string;
-  imageID: string;
   location: string;
   locationTypeID: number;
   program: string;
@@ -35,7 +35,7 @@ export module PostService {
    *
    * @param userID The ID of the user making the post.
    * @param content The text content of the post.
-   * @param imageData The binary data of the image associated with the post.
+   * @param imageData The binary data of the images associated with the post.
    * @param location The post's location.
    * @param locationTypeID The type ID of location.
    * @param program The program the user is in.
@@ -46,7 +46,7 @@ export module PostService {
   export async function createPost(
     userID: string,
     content: string,
-    imageData: Buffer,
+    imageData: Buffer[],
     location: string,
     locationTypeID: number,
     program: string,
@@ -54,23 +54,22 @@ export module PostService {
     threeWords: string
   ): Promise<string> {
     const postID = await newUniqueID("Post");
-    const imageID = await ImageService.createImage(imageData);
     const ratingID = await RatingService.createRating(rating);
+    await PostImageService.createPostImages(postID, imageData);
 
     const sql = `
       INSERT INTO Post (
-        id, userID, content, imageID, location, locationTypeID, program,
-        ratingID, threeWords, createTime
+        id, userID, content, location, locationTypeID, program, ratingID,
+        threeWords, createTime
       ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
+        ?, ?, ?, ?, ?, ?, ?
+        ?, ?
       );
     `;
     const params = [
       postID,
       userID,
       content,
-      imageID,
       location,
       locationTypeID,
       program,
@@ -117,7 +116,7 @@ export module PostService {
    * @param postID A post's ID.
    */
   export async function deletePost(postID: string): Promise<void> {
-    let sql = `SELECT imageID, ratingID FROM Post WHERE id = ?;`;
+    let sql = `SELECT ratingID FROM Post WHERE id = ?;`;
     let params = [postID];
     let rows: Post[] = await mainDB.execute(sql, params);
 
@@ -125,10 +124,9 @@ export module PostService {
     params = [postID];
     await mainDB.execute(sql, params);
 
-    const imageID = rows[0]?.imageID;
     const ratingID = rows[0]?.ratingID;
-    await ImageService.deleteImage(imageID);
     await RatingService.deleteRating(ratingID);
+    await PostImageService.deletePostImages(postID);
   }
 
   /**
@@ -185,7 +183,7 @@ export module PostService {
    * @param userID A user's ID.
    */
   export async function deleteUserPosts(userID: string): Promise<void> {
-    let sql = `SELECT imageID, ratingID FROM Post WHERE userID = ?;`;
+    let sql = `SELECT id, ratingID FROM Post WHERE userID = ?;`;
     let params = [userID];
     const rows: Post[] = await mainDB.execute(sql, params);
 
@@ -193,19 +191,17 @@ export module PostService {
     params = [userID];
     await mainDB.execute(sql, params);
 
-    const imageIDs = rows.map((post) => `'${post.imageID}'`);
     const ratingIDs = rows.map((post) => `'${post.ratingID}'`);
-
-    if (imageIDs.length > 0) {
-      sql = `DELETE FROM Image WHERE id IN (${imageIDs.join(", ")});`;
-      params = [];
-      await mainDB.execute(sql, params);
-    }
+    const postIDs = rows.map((post) => post.id);
 
     if (ratingIDs.length > 0) {
       sql = `DELETE FROM Rating WHERE id IN (${ratingIDs.join(", ")});`;
       params = [];
       await mainDB.execute(sql, params);
+    }
+
+    for (const postID of postIDs) {
+      await PostImageService.deletePostImages(postID);
     }
   }
 
@@ -239,47 +235,27 @@ export module PostService {
   }
 
   /**
-   * Get a post's image.
+   * Get a post's images.
    *
    * @param postID A post's ID.
-   * @returns The image associated with the post.
+   * @returns The images associated with the post.
    */
-  export async function getPostImage(postID: string): Promise<Image> {
-    const sql = `SELECT imageID from Post WHERE id = ?;`;
-    const params = [postID];
-    const rows: Post[] = await mainDB.execute(sql, params);
-
-    const imageID = rows[0]?.imageID;
-    const image = await ImageService.getImage(imageID);
-
-    return image;
+  export async function getPostImage(postID: string): Promise<Image[]> {
+    return await PostImageService.getPostImages(postID);
   }
 
   /**
-   * Set a post's image.
+   * Set a post's images.
    *
    * @param postID A post's ID.
-   * @param imageData The new binary image data.
-   * @returns The new image's ID.
+   * @param imageData The binary data of the new images.
+   * @returns The IDs of the new images.
    */
   export async function setPostImage(
     postID: string,
-    imageData: Buffer
-  ): Promise<string> {
-    let sql = `SELECT imageID from Post WHERE id = ?;`;
-    let params = [postID];
-    const rows: Post[] = await mainDB.execute(sql, params);
-
-    const newImageID = await ImageService.createImage(imageData);
-
-    sql = `UPDATE Post SET imageID = ? WHERE id = ?`;
-    params = [newImageID, postID];
-    await mainDB.execute(sql, params);
-
-    const imageID = rows[0]?.imageID;
-    await ImageService.deleteImage(imageID);
-
-    return newImageID;
+    imageData: Buffer[]
+  ): Promise<string[]> {
+    return await PostImageService.createPostImages(postID, imageData);
   }
 
   /**

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -260,11 +260,12 @@ export module PostService {
    *
    * @param postID A post's ID.
    * @param imageData The new binary image data.
+   * @returns The new image's ID.
    */
   export async function setPostImage(
     postID: string,
     imageData: Buffer
-  ): Promise<void> {
+  ): Promise<string> {
     let sql = `SELECT imageID from Post WHERE id = ?;`;
     let params = [postID];
     const rows: Post[] = await mainDB.execute(sql, params);
@@ -277,6 +278,8 @@ export module PostService {
 
     const imageID = rows[0]?.imageID;
     await ImageService.deleteImage(imageID);
+
+    return newImageID;
   }
 
   /**

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -240,7 +240,7 @@ export module PostService {
    * @param postID A post's ID.
    * @returns The images associated with the post.
    */
-  export async function getPostImage(postID: string): Promise<Image[]> {
+  export async function getPostImages(postID: string): Promise<Image[]> {
     return await PostImageService.getPostImages(postID);
   }
 
@@ -251,7 +251,7 @@ export module PostService {
    * @param imageData The binary data of the new images.
    * @returns The IDs of the new images.
    */
-  export async function setPostImage(
+  export async function setPostImages(
     postID: string,
     imageData: Buffer[]
   ): Promise<string[]> {

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -4,7 +4,7 @@
  */
 
 import mainDB, { getTime, newUniqueID } from "./util";
-import { Image, ImageService } from "./image";
+import { Image } from "./image";
 import { Rating, RatingParams, RatingService } from "./rating";
 import { User, UserService } from "./user";
 import { PostImageService } from "./postImage";
@@ -55,7 +55,6 @@ export module PostService {
   ): Promise<string> {
     const postID = await newUniqueID("Post");
     const ratingID = await RatingService.createRating(rating);
-    await PostImageService.createPostImages(postID, imageData);
 
     const sql = `
       INSERT INTO Post (
@@ -78,6 +77,8 @@ export module PostService {
       getTime(),
     ];
     await mainDB.execute(sql, params);
+
+    await PostImageService.createPostImages(postID, imageData);
 
     return postID;
   }

--- a/src/services/postImage.ts
+++ b/src/services/postImage.ts
@@ -28,7 +28,7 @@ export module PostImageService {
     const sql = `
       SELECT * FROM Image WHERE id IN (
         SELECT imageID FROM PostImage WHERE postID = ?
-      );`;
+      ) ORDER BY registerTime;`;
     const params = [postID];
     const rows: Image[] = await mainDB.execute(sql, params);
 

--- a/src/services/postImage.ts
+++ b/src/services/postImage.ts
@@ -106,7 +106,7 @@ export module PostImageService {
     const params = [postID];
     const rows = await mainDB.execute(sql, params);
 
-    return rows[0]["COUNT(*)"];
+    return parseInt(rows[0]["COUNT(*)"]);
   }
 
   /**
@@ -115,16 +115,18 @@ export module PostImageService {
    * @param postID A post's ID.
    */
   export async function deletePostImages(postID: string): Promise<void> {
-    let sql = `
-      DELETE FROM Image WHERE id IN (
-        SELECT imageID FROM PostImage WHERE postID = ?
-      );
-    `;
-    let params = [postID];
-    await mainDB.execute(sql, params);
+    let sql = `SELECT imageID FROM PostImage WHERE postID = ?`;
+    let params: any = [postID];
+    const rows: PostImage[] = await mainDB.execute(sql, params);
+
+    const imageIDs = rows.map((postImage) => postImage.imageID);
 
     sql = `DELETE FROM PostImage WHERE postID = ?;`;
     params = [postID];
+    await mainDB.execute(sql, params);
+
+    sql = `DELETE FROM Image WHERE id IN ?;`;
+    params = [imageIDs];
     await mainDB.execute(sql, params);
   }
 }

--- a/src/services/postImage.ts
+++ b/src/services/postImage.ts
@@ -60,7 +60,7 @@ export module PostImageService {
    * Create a new image and associate it with a post.
    *
    * @param postID A post's ID.
-   * @param imageData The new binary image data.
+   * @param imageData The binary data of the new image.
    * @returns The new image's ID.
    */
   export async function createPostImage(
@@ -71,6 +71,28 @@ export module PostImageService {
     await setPostImage(postID, imageID);
 
     return imageID;
+  }
+
+  /**
+   * Create new images and associate them with a post.
+   *
+   * @param postID A post's ID.
+   * @param imageData The binary data of the new images.
+   * @returns The IDs of the new images.
+   */
+  export async function createPostImages(
+    postID: string,
+    imageData: Buffer[]
+  ): Promise<string[]> {
+    let imageIDs: string[] = [];
+
+    for (const data of imageData) {
+      const imageID = await createPostImage(postID, data);
+      await setPostImage(postID, imageID);
+      imageIDs.push(imageID);
+    }
+
+    return imageIDs;
   }
 
   /**

--- a/src/services/postImage.ts
+++ b/src/services/postImage.ts
@@ -1,0 +1,108 @@
+/**
+ * Services for the post image table.
+ * @packageDocumentation
+ */
+
+import mainDB from "./util";
+import { Image, ImageService } from "./image";
+
+/**
+ * Post image architecture.
+ */
+export interface PostImage {
+  postID: string;
+  imageID: string;
+}
+
+/**
+ * Post image services.
+ */
+export module PostImageService {
+  /**
+   * Get all images associated with a post.
+   *
+   * @param postID A post's ID.
+   * @returns The images associated with the post.
+   */
+  export async function getPostImages(postID: string): Promise<Image[]> {
+    const sql = `
+      SELECT * FROM Image WHERE id IN (
+        SELECT imageID FROM PostImage WHERE postID = ?
+      );`;
+    const params = [postID];
+    const rows: Image[] = await mainDB.execute(sql, params);
+
+    return rows;
+  }
+
+  /**
+   * Associate an image with a post.
+   *
+   * @param postID A post's ID.
+   * @param imageID An image's ID.
+   */
+  export async function setPostImage(
+    postID: string,
+    imageID: string
+  ): Promise<void> {
+    const sql = `
+      INSERT INTO PostImage (
+        postID, imageID
+      ) VALUES (
+        ?, ?
+      );
+    `;
+    const params = [postID, imageID];
+    await mainDB.execute(sql, params);
+  }
+
+  /**
+   * Create a new image and associate it with a post.
+   *
+   * @param postID A post's ID.
+   * @param imageData The new binary image data.
+   * @returns The new image's ID.
+   */
+  export async function createPostImage(
+    postID: string,
+    imageData: Buffer
+  ): Promise<string> {
+    const imageID = await ImageService.createImage(imageData);
+    await setPostImage(postID, imageID);
+
+    return imageID;
+  }
+
+  /**
+   * Get the number of images associated with a post.
+   *
+   * @param postID A post's ID.
+   * @returns The number of images associated with the post.
+   */
+  export async function numImages(postID: string): Promise<number> {
+    const sql = `SELECT COUNT(*) FROM PostImage WHERE postID = ?;`;
+    const params = [postID];
+    const rows = await mainDB.execute(sql, params);
+
+    return rows[0]["COUNT(*)"];
+  }
+
+  /**
+   * Delete all images associated with a post.
+   *
+   * @param postID A post's ID.
+   */
+  export async function deletePostImages(postID: string): Promise<void> {
+    let sql = `
+      DELETE FROM Image WHERE id IN (
+        SELECT imageID FROM PostImage WHERE postID = ?
+      );
+    `;
+    let params = [postID];
+    await mainDB.execute(sql, params);
+
+    sql = `DELETE FROM PostImage WHERE postID = ?;`;
+    params = [postID];
+    await mainDB.execute(sql, params);
+  }
+}

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -460,7 +460,7 @@ test("Post", async () => {
   const postID = await PostService.createPost(
     userID,
     content,
-    buf,
+    [buf],
     location,
     locationTypeID,
     program,
@@ -505,16 +505,18 @@ test("Post", async () => {
   const newPostContent = await PostService.getPostContent(postID);
   expect(newPostContent).toBe(newContent);
 
-  // Get post image
-  const postImage = await PostService.getPostImage(postID);
-  expect(postImage.data.toString()).toBe(buf.toString());
+  // Get post images
+  const postImages = await PostService.getPostImages(postID);
+  expect(postImages.length).toBe(1);
+  expect(postImages[0].data.toString()).toBe(buf.toString());
 
   // Set post image
   const newLen = Math.floor(Math.random() * 63) + 1;
   const newBuf = crypto.randomBytes(newLen);
-  await PostService.setPostImage(postID, newBuf);
-  const newPostImage = await PostService.getPostImage(postID);
-  expect(newPostImage.data.toString()).toBe(newBuf.toString());
+  await PostService.setPostImages(postID, [newBuf]);
+  const newPostImages = await PostService.getPostImages(postID);
+  expect(newPostImages.length).toBe(2);
+  expect(newPostImages[1].data.toString()).toBe(newBuf.toString());
 
   // Check approved
   let approved = await PostService.isApproved(postID);
@@ -529,7 +531,7 @@ test("Post", async () => {
   const postID2 = await PostService.createPost(
     userID,
     content,
-    buf,
+    [buf],
     location,
     locationTypeID,
     program,
@@ -555,7 +557,7 @@ test("Post", async () => {
   const postID3 = await PostService.createPost(
     userID,
     content,
-    buf,
+    [buf],
     location,
     locationTypeID,
     program,

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -15,6 +15,7 @@ import { PostService } from "../src/services/post";
 import { MetaService } from "../src/services/meta";
 import { PasswordResetService } from "../src/services/passwordReset";
 import { VerifyService } from "../src/services/verify";
+import { PostImageService } from "../src/services/postImage";
 import { sendEmail } from "../src/emailer";
 
 async function wait(ms: number): Promise<void> {
@@ -682,12 +683,10 @@ test("PasswordReset", async () => {
     email,
     false
   );
-  const hashedPassword = (await UserService.getUser(userID)).password;
   success = await PasswordResetService.resetPassword(resetID4, newPassword);
   expect(success).toBe(true);
-  const hashedPassword2 = (await UserService.getUser(userID)).password;
-  expect(hashedPassword).not.toBe(hashedPassword2);
-  const match = await checkPassword(newPassword, hashedPassword2);
+  const newHashedPassword = (await UserService.getUser(userID)).password;
+  const match = await checkPassword(newPassword, newHashedPassword);
   expect(match).toBe(true);
 
   // Check record has been removed
@@ -760,6 +759,115 @@ test("Verify", async () => {
   // Check record has been removed
   recordExists = await VerifyService.verifyRecordExists(verifyID4);
   expect(recordExists).toBe(false);
+
+  await UserService.deleteUser(userID);
+});
+
+test("PostImage", async () => {
+  const firstname = "Martin";
+  const lastname = "Luther";
+  const email = "lumart01@luther.edu";
+  const password = "password123";
+  const statusID = 1; // Student
+
+  const userID = await UserService.createUser(
+    firstname,
+    lastname,
+    email,
+    password,
+    statusID
+  );
+
+  const content = "Hello, post!";
+  const location = "Mabe's Pizza";
+  const locationTypeID = 6; // Restaurant
+  const program = "N/A";
+  const threeWords = "Absolutely amazing pizza";
+
+  const rating = {
+    general: 1,
+    cost: 3,
+    safety: 7,
+  };
+
+  // Create post
+  const postID = await PostService.createPost(
+    userID,
+    content,
+    [],
+    location,
+    locationTypeID,
+    program,
+    rating,
+    threeWords
+  );
+
+  // Check no post images exist
+  let postImages = await PostImageService.getPostImages(postID);
+  expect(postImages.length).toBe(0);
+  let numImages = await PostImageService.numImages(postID);
+  expect(numImages).toBe(0);
+
+  // Check set post image
+  const len = Math.floor(Math.random() * 63) + 1;
+  const buf = crypto.randomBytes(len);
+  const imageID = await ImageService.createImage(buf);
+  await PostImageService.setPostImage(postID, imageID);
+  postImages = await PostImageService.getPostImages(postID);
+  expect(postImages.length).toBe(1);
+  expect(postImages[0].data.toString()).toBe(buf.toString());
+  numImages = await PostImageService.numImages(postID);
+  expect(numImages).toBe(1);
+
+  // Create post image
+  const len2 = Math.floor(Math.random() * 63) + 1;
+  const buf2 = crypto.randomBytes(len2);
+  const imageID2 = await PostImageService.createPostImage(postID, buf2);
+  postImages = await PostImageService.getPostImages(postID);
+  expect(postImages.length).toBe(2);
+  expect(postImages[1].id).toBe(imageID2);
+  expect(postImages[1].data.toString()).toBe(buf2.toString());
+  numImages = await PostImageService.numImages(postID);
+  expect(numImages).toBe(2);
+
+  // Create post images
+  const len3 = Math.floor(Math.random() * 63) + 1;
+  const buf3 = crypto.randomBytes(len3);
+  const len4 = Math.floor(Math.random() * 63) + 1;
+  const buf4 = crypto.randomBytes(len4);
+  const [imageID3, imageID4] = await PostImageService.createPostImages(
+    postID,
+    [buf3, buf4]
+  );
+  postImages = await PostImageService.getPostImages(postID);
+  expect(postImages.length).toBe(4);
+  expect(postImages[2].id).toBe(imageID3);
+  expect(postImages[2].data.toString()).toBe(buf3.toString());
+  expect(postImages[3].id).toBe(imageID4);
+  expect(postImages[3].data.toString()).toBe(buf4.toString());
+  numImages = await PostImageService.numImages(postID);
+  expect(numImages).toBe(4);
+
+  // Delete all post images
+  await PostImageService.deletePostImages(postID);
+  postImages = await PostImageService.getPostImages(postID);
+  expect(postImages.length).toBe(0);
+  numImages = await PostImageService.numImages(postID);
+  expect(numImages).toBe(0);
+
+  // Delete images upon post deletion
+  const len5 = Math.floor(Math.random() * 63) + 1;
+  const buf5 = crypto.randomBytes(len5);
+  const imageID5 = await PostImageService.createPostImage(postID, buf5);
+  numImages = await PostImageService.numImages(postID);
+  expect(numImages).toBe(1);
+  let imageExists = await ImageService.imageExists(imageID5);
+  expect(imageExists).toBe(true);
+  await PostService.deletePost(postID);
+  numImages = await PostImageService.numImages(postID);
+  expect(numImages).toBe(0);
+  imageExists = await ImageService.imageExists(imageID5);
+  expect(imageExists).toBe(false);
 
   await UserService.deleteUser(userID);
 });


### PR DESCRIPTION
To allow for multiple images per post, I have created the `PostImage` table, and its corresponding services/tests. The only thing that this currently breaks is the post image endpoint (`/image/post/:postID`). I will fix this shortly, in another branch.