### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jest-coverage-badges": "1.1.2",
     "prettier": "^2.2.1",
     "ts-jest": "^26.4.4",
-    "typedoc": "^0.19.2",
+    "typedoc": "^0.20.24",
     "typedoc-neo-theme": "^1.0.10",
     "typescript": "^4.1.2"
   }


### PR DESCRIPTION
`npm install` fails with the current version of Typedoc
The issue goes away after using the latest version