### PR TITLE
Handle missing post

### DIFF
--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -143,6 +143,7 @@ postRouter.get(
     const post = await dbm.postService.getPost(postID);
     if (!post) {
       next(); // 404
+      return;
     }
 
     const postUser = await dbm.postService.getPostUser(postID);


### PR DESCRIPTION
This fixes a bug which caused an error to be thrown when a user attempted to navigate to a nonexistent post.

closes #30 