### PR TITLE
Fix admin page width

### DIFF
--- a/src/static/css/admin.css
+++ b/src/static/css/admin.css
@@ -36,3 +36,8 @@ h1 {
   font-weight: bold;
   font-style: italic;
 }
+
+#content {
+  max-width: 9999px;
+  padding: 16px 20px;
+}


### PR DESCRIPTION
This fixes the admin page width. In a recent commit, the maximum width for all pages was set, which affected the appearance of the admin page.

closes #101 