### PR TITLE
Delete users and posts

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -62,6 +62,36 @@ apiRouter.get(
   })
 );
 
+// Delete a user
+apiRouter.get(
+  "/deleteUser",
+  adminAuth,
+  wrapRoute(async (req, res) => {
+    const dbm = getDBM(req);
+
+    const userID = req.query.userID as string;
+
+    await dbm.userService.deleteUser(userID);
+
+    res.end();
+  })
+);
+
+// Delete a post
+apiRouter.get(
+  "/deletePost",
+  adminAuth,
+  wrapRoute(async (req, res) => {
+    const dbm = getDBM(req);
+
+    const postID = req.query.postID as string;
+
+    await dbm.postService.deletePost(postID);
+
+    res.end();
+  })
+);
+
 // Admin variables
 apiRouter.get(
   "/adminVariables",

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -119,14 +119,13 @@ export class UserService extends BaseService {
    * @param userID A user's ID.
    */
   public async deleteUser(userID: string): Promise<void> {
+    await this.dbm.sessionService.deleteUserSessions(userID);
+    await this.dbm.postService.deleteUserPosts(userID);
     await this.deleteUserImage(userID);
 
     const sql = `DELETE FROM User WHERE id = ?;`;
     const params = [userID];
     await this.dbm.execute(sql, params);
-
-    await this.dbm.sessionService.deleteUserSessions(userID);
-    await this.dbm.postService.deleteUserPosts(userID);
   }
 
   /**

--- a/src/static/js/admin-stats.js
+++ b/src/static/js/admin-stats.js
@@ -66,6 +66,46 @@ function createPostRow(post) {
   return row;
 }
 
+// Delete a user's account
+function deleteUser(userID) {
+  $.ajax({
+    url: "/api/deleteUser",
+    data: {
+      userID,
+    },
+    success: () => {
+      hideError();
+      updateNotifications();
+      populateStats();
+      populateUsers();
+      populatePosts();
+    },
+    error: () => {
+      showError("Failed to delete user");
+    },
+  });
+}
+
+// Delete a post
+function deletePost(postID) {
+  $.ajax({
+    url: "/api/deletePost",
+    data: {
+      postID,
+    },
+    success: () => {
+      hideError();
+      updateNotifications();
+      populateStats();
+      populateUsers();
+      populatePosts();
+    },
+    error: () => {
+      showError("Failed to delete post");
+    },
+  });
+}
+
 // Populate statistics on the stats page
 async function populateStats() {
   const statsURL = "/api/adminStats";

--- a/src/static/js/admin-stats.js
+++ b/src/static/js/admin-stats.js
@@ -1,4 +1,6 @@
 const statsTimeout = 60 * 1000; // One minute
+let currentUserID = null;
+let currentPostID = null;
 
 // Create a row in the users table
 function createUserRow(user) {
@@ -19,6 +21,17 @@ function createUserRow(user) {
   const joinTime = newElement("td").text(
     new Date(parseInt(user.joinTime) * 1000).toLocaleString()
   );
+  const deleteUserButton = newElement("button")
+    .addClass("btn btn-danger")
+    .attr({
+      type: "button",
+    })
+    .html('<i class="fas fa-trash-alt"></i>')
+    .click(() => {
+      currentUserID = user.userID;
+      $("#deleteUserConfirmationModal").modal("show");
+    });
+  const deleteUser = newElement("td").append(deleteUserButton);
   const row = newElement("tr").append(
     userID,
     firstname,
@@ -28,7 +41,8 @@ function createUserRow(user) {
     verified,
     approved,
     admin,
-    joinTime
+    joinTime,
+    deleteUser
   );
   return row;
 }
@@ -54,6 +68,17 @@ function createPostRow(post) {
   const createTime = newElement("td").text(
     new Date(parseInt(post.createTime) * 1000).toLocaleString()
   );
+  const deletePostButton = newElement("button")
+    .addClass("btn btn-danger")
+    .attr({
+      type: "button",
+    })
+    .html('<i class="fas fa-trash-alt"></i>')
+    .click(() => {
+      currentPostID = post.postID;
+      $("#deletePostConfirmationModal").modal("show");
+    });
+  const deletePost = newElement("td").append(deletePostButton);
   const row = newElement("tr").append(
     postID,
     location,
@@ -61,7 +86,8 @@ function createPostRow(post) {
     program,
     rating,
     approved,
-    createTime
+    createTime,
+    deletePost
   );
   return row;
 }
@@ -86,6 +112,12 @@ function deleteUser(userID) {
   });
 }
 
+// Delete the current user's account
+function deleteCurrentUser() {
+  $("#deleteUserConfirmationModal").modal("hide");
+  deleteUser(currentUserID);
+}
+
 // Delete a post
 function deletePost(postID) {
   $.ajax({
@@ -104,6 +136,12 @@ function deletePost(postID) {
       showError("Failed to delete post");
     },
   });
+}
+
+// Delete the current post
+function deleteCurrentPost() {
+  $("#deletePostConfirmationModal").modal("hide");
+  deletePost(currentPostID);
 }
 
 // Populate statistics on the stats page

--- a/src/views/admin-stats.html
+++ b/src/views/admin-stats.html
@@ -23,6 +23,7 @@
     <th scope="col">Approved</th>
     <th scope="col">Admin</th>
     <th scope="col">Join time</th>
+    <th scope="col">Delete</th>
   </thead>
   <tbody id="site-users"></tbody>
 </table>
@@ -40,6 +41,7 @@
     <th scope="col">Rating</th>
     <th scope="col">Approved</th>
     <th scope="col">Create time</th>
+    <th scope="col">Delete</th>
   </thead>
   <tbody id="site-posts"></tbody>
 </table>
@@ -77,7 +79,11 @@
         <button type="button" class="btn btn-secondary" data-dismiss="modal">
           Close
         </button>
-        <button type="button" class="btn btn-danger" onclick="deleteUser();">
+        <button
+          type="button"
+          class="btn btn-danger"
+          onclick="deleteCurrentUser();"
+        >
           Delete
         </button>
       </div>
@@ -114,7 +120,11 @@
         <button type="button" class="btn btn-secondary" data-dismiss="modal">
           Close
         </button>
-        <button type="button" class="btn btn-danger" onclick="deletePost();">
+        <button
+          type="button"
+          class="btn btn-danger"
+          onclick="deleteCurrentPost();"
+        >
           Delete
         </button>
       </div>

--- a/src/views/admin-stats.html
+++ b/src/views/admin-stats.html
@@ -44,3 +44,80 @@
   <tbody id="site-posts"></tbody>
 </table>
 <p id="posts-status">Fetching posts...</p>
+
+<div
+  class="modal fade"
+  id="deleteUserConfirmationModal"
+  tabindex="-1"
+  aria-labelledby="deleteUserConfirmationModalLabel"
+  aria-hidden="true"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteUserConfirmationModalLabel">
+          Delete user confirmation
+        </h5>
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>
+          Are you sure you want to permanently delete this user and all their
+          posts?
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+          Close
+        </button>
+        <button type="button" class="btn btn-danger" onclick="deleteUser();">
+          Delete
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div
+  class="modal fade"
+  id="deletePostConfirmationModal"
+  tabindex="-1"
+  aria-labelledby="deletePostConfirmationModalLabel"
+  aria-hidden="true"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deletePostConfirmationModalLabel">
+          Delete post confirmation
+        </h5>
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to permanently delete this post?</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+          Close
+        </button>
+        <button type="button" class="btn btn-danger" onclick="deletePost();">
+          Delete
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/views/admin-stats.html
+++ b/src/views/admin-stats.html
@@ -71,7 +71,7 @@
       </div>
       <div class="modal-body">
         <p>
-          Are you sure you want to permanently delete this user and all their
+          Are you sure you want to permanently delete this user and all of their
           posts?
         </p>
       </div>


### PR DESCRIPTION
Admins can now delete users and posts from the admin control panel stats page. A confirmation dialog is shown before deletion.