### PR TITLE
Post user status

### DIFF
--- a/src/dbinit.ts
+++ b/src/dbinit.ts
@@ -176,20 +176,21 @@ export default async function initDB(
   `;
   const postTable = `
     CREATE TABLE IF NOT EXISTS Post (
-      id             CHAR(4)      NOT NULL,
-      userID         CHAR(4)      NOT NULL,
-      content        VARCHAR(750) NOT NULL,
-      location       VARCHAR(255) NOT NULL,
-      locationTypeID INT          NOT NULL,
-      programID      INT UNSIGNED NOT NULL,
-      ratingID       CHAR(4)      NOT NULL,
-      threeWords     VARCHAR(63)  NOT NULL,
-      address        VARCHAR(255),
-      phone          VARCHAR(13),
-      website        VARCHAR(255),
-      approved       BOOL         NOT NULL DEFAULT FALSE,
-      createTime     INT UNSIGNED NOT NULL,
-      editTime       INT UNSIGNED,
+      id                  CHAR(4)      NOT NULL,
+      userID              CHAR(4)      NOT NULL,
+      content             VARCHAR(750) NOT NULL,
+      location            VARCHAR(255) NOT NULL,
+      locationTypeID      INT          NOT NULL,
+      programID           INT UNSIGNED NOT NULL,
+      ratingID            CHAR(4)      NOT NULL,
+      threeWords          VARCHAR(63)  NOT NULL,
+      currentUserStatusID INT          NOT NULL,
+      address             VARCHAR(255),
+      phone               VARCHAR(13),
+      website             VARCHAR(255),
+      approved            BOOL         NOT NULL DEFAULT FALSE,
+      createTime          INT UNSIGNED NOT NULL,
+      editTime            INT UNSIGNED,
 
       PRIMARY KEY (id),
 
@@ -203,7 +204,10 @@ export default async function initDB(
         REFERENCES Program (id),
 
       FOREIGN KEY (ratingID)
-        REFERENCES Rating (id)
+        REFERENCES Rating (id),
+
+      FOREIGN KEY (currentUserStatusID)
+        REFERENCES UserStatus (id)
     );
   `;
   const postImageTable = `

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -240,7 +240,7 @@ postRouter.get(
     }
 
     const postUserStatusName = await dbm.userStatusService.getStatusName(
-      postUser.statusID
+      post.currentUserStatusID
     );
     const program = await dbm.programService.getProgramName(post.programID);
     const images = await dbm.postService.getPostImages(postID);

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -20,6 +20,7 @@ export interface Post {
   programID: number;
   ratingID: string;
   threeWords: string;
+  currentUserStatusID: number;
   address: string | null;
   phone: string | null;
   website: string | null;
@@ -63,14 +64,15 @@ export class PostService extends BaseService {
   ): Promise<string> {
     const postID = await newUniqueID(this.dbm, "Post");
     const ratingID = await this.dbm.ratingService.createRating(rating);
+    const user = await this.dbm.userService.getUser(userID);
 
     const sql = `
       INSERT INTO Post (
         id, userID, content, location, locationTypeID, programID, ratingID,
-        threeWords, address, phone, website, createTime
+        threeWords, currentUserStatusID, address, phone, website, createTime
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?
+        ?, ?, ?, ?, ?, ?
       );
     `;
     const params = [
@@ -82,6 +84,7 @@ export class PostService extends BaseService {
       programID,
       ratingID,
       threeWords,
+      user.statusID,
       address,
       phone,
       website,

--- a/test/services/post.test.ts
+++ b/test/services/post.test.ts
@@ -1,4 +1,4 @@
-import { getDBM, closeDBM, wait } from "./util";
+import { getDBM, closeDBM, wait, getByProp } from "./util";
 import * as crypto from "crypto";
 import { getTime } from "../../src/services/util";
 
@@ -67,22 +67,24 @@ test("Post", async () => {
   expect(post.locationTypeID).toBe(locationTypeID);
   expect(post.programID).toBe(programID);
   expect(post.threeWords).toBe(threeWords);
+  expect(post.currentUserStatusID).toBe(statusID);
   expect(post.approved).toBeFalsy();
   expect(post.createTime - getTime()).toBeLessThanOrEqual(3);
   expect(post.editTime).toBeNull();
 
   // Get unapproved posts
-  let unapproved = await dbm.postService.getUnapproved();
-  expect(unapproved.length).toBeGreaterThanOrEqual(1);
-  expect(unapproved[0]["postID"]).toBe(postID);
-  expect(unapproved[0]["firstname"]).toBe(firstname);
-  expect(unapproved[0]["lastname"]).toBe(lastname);
-  expect(unapproved[0].content).toBe(content);
-  expect(unapproved[0].location).toBe(location);
-  expect(unapproved[0]["locationType"]).toBe("Restaurant");
-  expect(unapproved[0]["program"]).toBe(programName);
-  expect(unapproved[0].threeWords).toBe(threeWords);
-  expect(unapproved[0].createTime - getTime()).toBeLessThanOrEqual(3);
+  let unapprovedPosts = await dbm.postService.getUnapproved();
+  expect(unapprovedPosts.length).toBeGreaterThanOrEqual(1);
+  const unapproved = getByProp(unapprovedPosts, "postID", postID);
+  expect(unapproved["postID"]).toBe(postID);
+  expect(unapproved["firstname"]).toBe(firstname);
+  expect(unapproved["lastname"]).toBe(lastname);
+  expect(unapproved.content).toBe(content);
+  expect(unapproved.location).toBe(location);
+  expect(unapproved["locationType"]).toBe("Restaurant");
+  expect(unapproved["program"]).toBe(programName);
+  expect(unapproved.threeWords).toBe(threeWords);
+  expect(unapproved.createTime - getTime()).toBeLessThanOrEqual(3);
 
   // Get post user
   const postUser = await dbm.postService.getPostUser(postID);
@@ -124,8 +126,8 @@ test("Post", async () => {
   await dbm.postService.setApproved(postID);
   approved = await dbm.postService.isApproved(postID);
   expect(approved).toBe(true);
-  unapproved = await dbm.postService.getUnapproved();
-  expect(unapproved.length).toBeGreaterThanOrEqual(0);
+  unapprovedPosts = await dbm.postService.getUnapproved();
+  expect(unapprovedPosts.length).toBeGreaterThanOrEqual(0);
 
   // Get all user posts
   const postID2 = await dbm.postService.createPost(


### PR DESCRIPTION
User statuses are now stored with posts. They will be displayed on `post/:postID` pages instead of the post creator's current status. When a user changes their status, their posts will not update the user status ID value.