### PR TITLE
Service return types

### DIFF
--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -4,8 +4,42 @@
  */
 
 import { BaseService } from "./util";
-import { User } from "./user";
-import { Post } from "./post";
+
+/**
+ * Admin record count architecture.
+ */
+interface AdminRecordCount {
+  count: number;
+}
+
+/**
+ * Admin user architecture.
+ */
+export interface AdminUser {
+  userID: string;
+  firstname: string;
+  lastname: string;
+  email: string;
+  status: string;
+  verified: boolean;
+  approved: boolean;
+  admin: boolean;
+  joinTime: number;
+}
+
+/**
+ * Admin post architecture.
+ */
+export interface AdminPost {
+  postID: string;
+  location: string;
+  postUser: string;
+  program: string;
+  rating: number;
+  approved: boolean;
+  createTime: number;
+  adminFavorite: string | null;
+}
 
 /**
  * Admin services.
@@ -19,7 +53,7 @@ export class AdminService extends BaseService {
    */
   public async getRecords(table: string): Promise<number> {
     const sql = `SELECT COUNT(*) AS count FROM ${table}`;
-    const rows = await this.dbm.execute(sql);
+    const rows: AdminRecordCount[] = await this.dbm.execute(sql);
     return rows[0].count;
   }
 
@@ -28,7 +62,7 @@ export class AdminService extends BaseService {
    *
    * @returns All users in the database.
    */
-  public async getUsers(): Promise<User[]> {
+  public async getUsers(): Promise<AdminUser[]> {
     const sql = `
       SELECT
           User.id AS userID, firstname, lastname, email,
@@ -37,7 +71,7 @@ export class AdminService extends BaseService {
         JOIN UserStatus ON User.statusID = UserStatus.id
       ORDER BY User.joinTime;
     `;
-    const rows: User[] = await this.dbm.execute(sql);
+    const rows: AdminUser[] = await this.dbm.execute(sql);
 
     return rows;
   }
@@ -47,7 +81,7 @@ export class AdminService extends BaseService {
    *
    * @returns All posts in the database.
    */
-  public async getPosts(): Promise<Post[]> {
+  public async getPosts(): Promise<AdminPost[]> {
     const sql = `
       SELECT
           Post.id AS postID, location,
@@ -62,7 +96,7 @@ export class AdminService extends BaseService {
         LEFT JOIN AdminFavorites ON Post.id = AdminFavorites.postID
       ORDER BY Post.createTime;
     `;
-    const rows: Post[] = await this.dbm.execute(sql);
+    const rows: AdminPost[] = await this.dbm.execute(sql);
 
     return rows;
   }

--- a/src/services/image.ts
+++ b/src/services/image.ts
@@ -15,6 +15,13 @@ export interface Image {
 }
 
 /**
+ * Image with only ID architecture.
+ */
+interface ImageID {
+  id: string;
+}
+
+/**
  * Image services.
  */
 export class ImageService extends BaseService {
@@ -43,7 +50,7 @@ export class ImageService extends BaseService {
   public async imageExists(imageID: string): Promise<boolean> {
     const sql = `SELECT id FROM Image WHERE id = ?;`;
     const params = [imageID];
-    const rows: Image[] = await this.dbm.execute(sql, params);
+    const rows: ImageID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }

--- a/src/services/locationType.ts
+++ b/src/services/locationType.ts
@@ -14,6 +14,20 @@ export interface LocationType {
 }
 
 /**
+ * Location type with only ID architecture.
+ */
+interface LocationTypeID {
+  id: number;
+}
+
+/**
+ * Location type with only name architecture.
+ */
+interface LocationTypeName {
+  name: string;
+}
+
+/**
  * Location type services.
  */
 export class LocationTypeService extends BaseService {
@@ -23,7 +37,7 @@ export class LocationTypeService extends BaseService {
    * @returns All location types.
    */
   public async getLocations(): Promise<LocationType[]> {
-    const sql = `SELECT id, name FROM LocationType ORDER BY id;`;
+    const sql = `SELECT * FROM LocationType ORDER BY id;`;
     const rows: LocationType[] = await this.dbm.execute(sql);
 
     return rows;
@@ -38,7 +52,7 @@ export class LocationTypeService extends BaseService {
   public async getLocationName(locationID: number): Promise<string> {
     const sql = `SELECT name FROM LocationType WHERE id = ?;`;
     const params = [locationID];
-    const rows: LocationType[] = await this.dbm.execute(sql, params);
+    const rows: LocationTypeName[] = await this.dbm.execute(sql, params);
 
     return rows[0]?.name;
   }
@@ -52,7 +66,7 @@ export class LocationTypeService extends BaseService {
   public async validLocation(locationID: number): Promise<boolean> {
     const sql = `SELECT id FROM LocationType WHERE id = ?;`;
     const params = [locationID];
-    const rows: LocationType[] = await this.dbm.execute(sql, params);
+    const rows: LocationTypeID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -14,6 +14,20 @@ export interface Meta {
 }
 
 /**
+ * Meta with only name architecture.
+ */
+interface MetaName {
+  name: string;
+}
+
+/**
+ * Meta with only value architecture.
+ */
+interface MetaValue {
+  value: string;
+}
+
+/**
  * Meta services.
  */
 export class MetaService extends BaseService {
@@ -26,7 +40,7 @@ export class MetaService extends BaseService {
   public async exists(name: string): Promise<boolean> {
     const sql = `SELECT name FROM Meta WHERE name = ?;`;
     const params = [name];
-    const rows: Meta[] = await this.dbm.execute(sql, params);
+    const rows: MetaName[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -40,7 +54,7 @@ export class MetaService extends BaseService {
   public async get(name: string): Promise<string> {
     const sql = `SELECT value FROM Meta WHERE name = ?;`;
     const params = [name];
-    const rows: Meta[] = await this.dbm.execute(sql, params);
+    const rows: MetaValue[] = await this.dbm.execute(sql, params);
 
     return rows[0]?.value;
   }

--- a/src/services/passwordReset.ts
+++ b/src/services/passwordReset.ts
@@ -21,6 +21,13 @@ export interface PasswordReset {
 }
 
 /**
+ * Password reset with only ID architecture.
+ */
+interface PasswordResetID {
+  id: string;
+}
+
+/**
  * Password reset services.
  */
 export class PasswordResetService extends BaseService {
@@ -53,7 +60,7 @@ export class PasswordResetService extends BaseService {
     // Check that no password reset has already been requested
     let sql = `SELECT id FROM PasswordReset WHERE email = ?;`;
     let params: any[] = [email];
-    let rows: PasswordReset[] = await this.dbm.execute(sql, params);
+    let rows: PasswordResetID[] = await this.dbm.execute(sql, params);
 
     if (rows.length > 0) {
       return null;
@@ -92,7 +99,7 @@ export class PasswordResetService extends BaseService {
   public async resetRecordExists(resetID: string): Promise<boolean> {
     const sql = `SELECT id FROM PasswordReset WHERE id = ?;`;
     const params = [resetID];
-    const rows: PasswordReset[] = await this.dbm.execute(sql, params);
+    const rows: PasswordResetID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -30,6 +30,71 @@ export interface Post {
 }
 
 /**
+ * Post with only ID architecture.
+ */
+interface PostID {
+  id: string;
+}
+
+/**
+ * Post with only user ID architecture.
+ */
+interface PostUserID {
+  userID: string;
+}
+
+/**
+ * Post with only rating ID architecture.
+ */
+interface PostRatingID {
+  ratingID: string;
+}
+
+/**
+ * Post with only content architecture.
+ */
+interface PostContent {
+  content: string;
+}
+
+/**
+ * Post with only approved architecture.
+ */
+interface PostApproved {
+  approved: boolean;
+}
+
+/**
+ * Post with only ID and rating ID architecture.
+ */
+interface PostIDRatingID {
+  id: string;
+  ratingID: string;
+}
+
+/**
+ * Unapproved post architecture.
+ */
+export interface UnapprovedPost {
+  postID: string;
+  firstname: string;
+  lastname: string;
+  content: string;
+  location: string;
+  locationType: string;
+  program: string;
+  threeWords: string;
+  createTime: number;
+}
+
+/**
+ * User post architecture.
+ */
+export interface UserPost extends Post {
+  program: string;
+}
+
+/**
  * Post services.
  */
 export class PostService extends BaseService {
@@ -107,7 +172,7 @@ export class PostService extends BaseService {
   public async postExists(postID: string): Promise<boolean> {
     const sql = `SELECT id FROM Post WHERE id = ?;`;
     const params = [postID];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: PostID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -134,7 +199,7 @@ export class PostService extends BaseService {
   public async deletePost(postID: string): Promise<void> {
     let sql = `SELECT ratingID FROM Post WHERE id = ?;`;
     let params = [postID];
-    let rows: Post[] = await this.dbm.execute(sql, params);
+    let rows: PostRatingID[] = await this.dbm.execute(sql, params);
 
     await this.dbm.postImageService.deletePostImages(postID);
 
@@ -155,7 +220,7 @@ export class PostService extends BaseService {
   public async getPostUser(postID: string): Promise<User> {
     const sql = `SELECT userID FROM Post WHERE id = ?;`;
     const params = [postID];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: PostUserID[] = await this.dbm.execute(sql, params);
 
     const userID = rows[0]?.userID;
     const user = await this.dbm.userService.getUser(userID);
@@ -172,7 +237,7 @@ export class PostService extends BaseService {
   public async getPostRating(postID: string): Promise<Rating> {
     const sql = `SELECT ratingID FROM Post WHERE id = ?;`;
     const params = [postID];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: PostRatingID[] = await this.dbm.execute(sql, params);
 
     const ratingID = rows[0]?.ratingID;
     const rating = await this.dbm.ratingService.getRating(ratingID);
@@ -186,7 +251,7 @@ export class PostService extends BaseService {
    * @param userID A user's ID.
    * @returns A list of all posts made by the user.
    */
-  public async getUserPosts(userID: string): Promise<Post[]> {
+  public async getUserPosts(userID: string): Promise<UserPost[]> {
     const sql = `
       SELECT Post.*, Program.name AS program
         FROM Post
@@ -195,7 +260,7 @@ export class PostService extends BaseService {
       ORDER BY Post.createTime;
     `;
     const params = [userID];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: UserPost[] = await this.dbm.execute(sql, params);
 
     return rows;
   }
@@ -208,7 +273,7 @@ export class PostService extends BaseService {
   public async deleteUserPosts(userID: string): Promise<void> {
     let sql = `SELECT id, ratingID FROM Post WHERE userID = ?;`;
     let params = [userID];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: PostIDRatingID[] = await this.dbm.execute(sql, params);
 
     const postIDs = rows.map((post) => post.id);
 
@@ -238,7 +303,7 @@ export class PostService extends BaseService {
   public async getPostContent(postID: string): Promise<string> {
     const sql = `SELECT content FROM Post WHERE id = ?;`;
     const params = [postID];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: PostContent[] = await this.dbm.execute(sql, params);
 
     return rows[0]?.content;
   }
@@ -288,7 +353,7 @@ export class PostService extends BaseService {
   public async isApproved(postID: string): Promise<boolean> {
     const sql = `SELECT approved FROM Post WHERE id = ?;`;
     const params = [postID];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: PostApproved[] = await this.dbm.execute(sql, params);
 
     return !!rows[0]?.approved;
   }
@@ -313,7 +378,7 @@ export class PostService extends BaseService {
    *
    * @returns All unapproved posts.
    */
-  public async getUnapproved(): Promise<Post[]> {
+  public async getUnapproved(): Promise<UnapprovedPost[]> {
     const sql = `
       SELECT
         Post.id AS postID, User.firstname AS firstname,
@@ -330,7 +395,7 @@ export class PostService extends BaseService {
       WHERE Post.approved = FALSE
       ORDER BY createTime;
     `;
-    const rows: Post[] = await this.dbm.execute(sql);
+    const rows: UnapprovedPost[] = await this.dbm.execute(sql);
 
     return rows;
   }

--- a/src/services/program.ts
+++ b/src/services/program.ts
@@ -14,6 +14,34 @@ export interface Program {
 }
 
 /**
+ * Program with only ID architecture.
+ */
+interface ProgramID {
+  id: number;
+}
+
+/**
+ * Program with only name architecture.
+ */
+interface ProgramName {
+  name: string;
+}
+
+/**
+ * Program count architecture.
+ */
+interface ProgramCount {
+  count: number;
+}
+
+/**
+ * Program with last insert ID architecture.
+ */
+interface ProgramInsertID {
+  id: number;
+}
+
+/**
  * Program services.
  */
 export class ProgramService extends BaseService {
@@ -33,7 +61,10 @@ export class ProgramService extends BaseService {
     `;
     const sql2 = `SELECT LAST_INSERT_ID() AS id;`;
     const params1 = [name];
-    const rows = await this.dbm.db.executeMany([sql1, sql2], [params1, []]);
+    const rows: ProgramInsertID[][] = await this.dbm.db.executeMany(
+      [sql1, sql2],
+      [params1, []]
+    );
 
     return rows[1][0].id;
   }
@@ -47,7 +78,7 @@ export class ProgramService extends BaseService {
   public async programExists(programID: number): Promise<boolean> {
     const sql = `SELECT id FROM Program WHERE id = ?;`;
     const params = [programID];
-    const rows: Program[] = await this.dbm.execute(sql, params);
+    const rows: ProgramID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -85,7 +116,7 @@ export class ProgramService extends BaseService {
   public async getProgramName(programID: number): Promise<string> {
     const sql = `SELECT name FROM Program WHERE id = ?;`;
     const params = [programID];
-    const rows: Program[] = await this.dbm.execute(sql, params);
+    const rows: ProgramName[] = await this.dbm.execute(sql, params);
 
     return rows[0].name;
   }
@@ -125,10 +156,10 @@ export class ProgramService extends BaseService {
    * @returns The number of linked posts.
    */
   public async numLinkedPosts(programID: number): Promise<number> {
-    const sql = `SELECT COUNT(*) AS posts FROM Post WHERE programID = ?;`;
+    const sql = `SELECT COUNT(*) AS count FROM Post WHERE programID = ?;`;
     const params = [programID];
-    const rows = await this.dbm.execute(sql, params);
+    const rows: ProgramCount[] = await this.dbm.execute(sql, params);
 
-    return rows[0].posts;
+    return rows[0].count;
   }
 }

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -4,7 +4,6 @@
  */
 
 import { BaseService } from "./util";
-import { Post } from "./post";
 
 /**
  * Query parameters.

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -28,6 +28,15 @@ export type QuerySortOptions =
   | "timestamp";
 
 /**
+ * Query post architecture.
+ */
+export interface QueryPost {
+  id: string;
+  location: string;
+  rating: number;
+}
+
+/**
  * Query services.
  */
 export class QueryService extends BaseService {
@@ -37,7 +46,7 @@ export class QueryService extends BaseService {
    * @param search Search parameters.
    * @returns All posts that match the search parameters.
    */
-  public async query(search: string): Promise<Post[]> {
+  public async query(search: string): Promise<QueryPost[]> {
     const searchLike = "%" + search + "%";
 
     const sql = `
@@ -58,7 +67,7 @@ export class QueryService extends BaseService {
       ORDER BY Post.createTime DESC;
     `;
     const params = [searchLike, searchLike, searchLike];
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: QueryPost[] = await this.dbm.execute(sql, params);
 
     return rows;
   }
@@ -75,7 +84,7 @@ export class QueryService extends BaseService {
     parameters: QueryParams,
     sortBy: QuerySortOptions,
     sortAscending: boolean = true
-  ): Promise<Post[]> {
+  ): Promise<QueryPost[]> {
     const whereOptions = {
       programIDs: "Post.programID",
       locationTypeIDs: "Post.locationTypeID",
@@ -150,7 +159,7 @@ export class QueryService extends BaseService {
     }
 
     const sql = `${sqlStart} WHERE ${whereClause.join(" AND ")} ${sqlEnd}`;
-    const rows: Post[] = await this.dbm.execute(sql, params);
+    const rows: QueryPost[] = await this.dbm.execute(sql, params);
 
     return rows;
   }

--- a/src/services/rating.ts
+++ b/src/services/rating.ts
@@ -31,6 +31,13 @@ export interface RatingParams {
 }
 
 /**
+ * Rating with only ID architecture.
+ */
+interface RatingID {
+  id: string;
+}
+
+/**
  * Rating services.
  */
 export class RatingService extends BaseService {
@@ -67,7 +74,7 @@ export class RatingService extends BaseService {
   public async ratingExists(ratingID: string): Promise<boolean> {
     const sql = `SELECT id FROM Rating WHERE id = ?;`;
     const params = [ratingID];
-    const rows: Rating[] = await this.dbm.execute(sql, params);
+    const rows: RatingID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -23,6 +23,20 @@ export interface Session {
 }
 
 /**
+ * Session with only ID architecture.
+ */
+interface SessionID {
+  id: string;
+}
+
+/**
+ * Session with only user ID architecture.
+ */
+interface SessionUserID {
+  userID: string;
+}
+
+/**
  * Session services.
  */
 export class SessionService extends BaseService {
@@ -70,7 +84,7 @@ export class SessionService extends BaseService {
   public async sessionExists(sessionID: string): Promise<boolean> {
     const sql = `SELECT id FROM Session WHERE id = ?;`;
     const params = [sessionID];
-    const rows: Session[] = await this.dbm.execute(sql, params);
+    const rows: SessionID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -134,7 +148,7 @@ export class SessionService extends BaseService {
   public async getUserIDBySessionID(sessionID: string): Promise<string> {
     const sql = `SELECT userID from Session WHERE id = ?;`;
     const params = [sessionID];
-    const rows: Session[] = await this.dbm.execute(sql, params);
+    const rows: SessionUserID[] = await this.dbm.execute(sql, params);
 
     return rows[0]?.userID;
   }

--- a/src/services/suspended.ts
+++ b/src/services/suspended.ts
@@ -17,6 +17,22 @@ export interface Suspended {
 }
 
 /**
+ * Suspended with only ID architecture.
+ */
+interface SuspendedID {
+  id: string;
+}
+
+/**
+ * Suspended user architecture.
+ */
+export interface SuspendedUser extends User {
+  status: string;
+  suspensionID: string;
+  suspendedUntil: number;
+}
+
+/**
  * Suspended services.
  */
 export class SuspendedService extends BaseService {
@@ -37,7 +53,7 @@ export class SuspendedService extends BaseService {
 
     let sql = `SELECT id FROM Suspended WHERE userID = ?;`;
     let params: any[] = [userID];
-    const rows: Suspended[] = await this.dbm.execute(sql, params);
+    const rows: SuspendedID[] = await this.dbm.execute(sql, params);
 
     if (rows.length === 0) {
       sql = `
@@ -71,7 +87,7 @@ export class SuspendedService extends BaseService {
   public async suspensionExists(suspensionID: string): Promise<boolean> {
     const sql = `SELECT id FROM Suspended WHERE id = ?;`;
     const params = [suspensionID];
-    const rows: Suspended[] = await this.dbm.execute(sql, params);
+    const rows: SuspendedID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -110,7 +126,7 @@ export class SuspendedService extends BaseService {
   public async userIsSuspended(userID: string): Promise<boolean> {
     const sql = `SELECT id FROM Suspended WHERE userID = ?;`;
     const params = [userID];
-    const rows: Suspended[] = await this.dbm.execute(sql, params);
+    const rows: SuspendedID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -120,7 +136,7 @@ export class SuspendedService extends BaseService {
    *
    * @returns All suspended users
    */
-  public async suspendedUsers(): Promise<User[]> {
+  public async suspendedUsers(): Promise<SuspendedUser[]> {
     const sql = `
       SELECT
           User.*, UserStatus.name AS status, Suspended.id AS suspensionID,
@@ -130,7 +146,7 @@ export class SuspendedService extends BaseService {
         JOIN UserStatus ON User.statusID = UserStatus.id
       ORDER BY Suspended.suspendedUntil;
     `;
-    const rows: User[] = await this.dbm.execute(sql);
+    const rows: SuspendedUser[] = await this.dbm.execute(sql);
 
     return rows;
   }

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -41,6 +41,75 @@ export interface User {
 }
 
 /**
+ * User with only ID architecture.
+ */
+interface UserID {
+  id: string;
+}
+
+/**
+ * User with only email architecture.
+ */
+interface UserEmail {
+  email: string;
+}
+
+/**
+ * User with only status ID architecture.
+ */
+interface UserStatusID {
+  statusID: number;
+}
+
+/**
+ * User with only verified architecture.
+ */
+interface UserVerified {
+  verified: boolean;
+}
+
+/**
+ * User with only approved architecture.
+ */
+interface UserApproved {
+  approved: boolean;
+}
+
+/**
+ * User with only admin architecture.
+ */
+interface UserAdmin {
+  admin: boolean;
+}
+
+/**
+ * User with only image ID architecture.
+ */
+interface UserImageID {
+  imageID: string | null;
+}
+
+/**
+ * User with only ID and password architecture.
+ */
+interface UserIDPassword {
+  id: string;
+  password: string;
+}
+
+/**
+ * Unapproved users architecture.
+ */
+export interface UnapprovedUsers {
+  userID: string;
+  firstname: string;
+  lastname: string;
+  email: string;
+  status: string;
+  joinTime: number;
+}
+
+/**
  * User services.
  */
 export class UserService extends BaseService {
@@ -94,7 +163,7 @@ export class UserService extends BaseService {
   public async userExists(userID: string): Promise<boolean> {
     const sql = `SELECT id FROM User WHERE id = ?;`;
     const params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -151,7 +220,7 @@ export class UserService extends BaseService {
   public async uniqueEmail(email: string): Promise<boolean> {
     const sql = `SELECT email FROM User WHERE email = ?;`;
     const params = [email];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserEmail[] = await this.dbm.execute(sql, params);
 
     return rows.length === 0;
   }
@@ -166,7 +235,7 @@ export class UserService extends BaseService {
   public async login(email: string, password: string): Promise<LoginStatus> {
     let sql = `SELECT id, password FROM User WHERE email = ? AND verified = TRUE AND approved = TRUE;`;
     let params: any[] = [email];
-    let rows: User[] = await this.dbm.execute(sql, params);
+    let rows: UserIDPassword[] = await this.dbm.execute(sql, params);
 
     const hash = rows[0]?.password || "";
     const same = await checkPassword(password, hash);
@@ -197,7 +266,7 @@ export class UserService extends BaseService {
   public async getUserStatusName(userID: string): Promise<string> {
     const sql = `SELECT statusID FROM User WHERE id = ?;`;
     const params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserStatusID[] = await this.dbm.execute(sql, params);
 
     const statusID = rows[0]?.statusID;
     const statusName = await this.dbm.userStatusService.getStatusName(statusID);
@@ -214,7 +283,7 @@ export class UserService extends BaseService {
   public async isVerified(userID: string): Promise<boolean> {
     const sql = `SELECT verified FROM User WHERE id = ?;`;
     const params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserVerified[] = await this.dbm.execute(sql, params);
 
     return !!rows[0]?.verified;
   }
@@ -243,7 +312,7 @@ export class UserService extends BaseService {
   public async isApproved(userID: string): Promise<boolean> {
     const sql = `SELECT approved FROM User WHERE id = ?;`;
     const params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserApproved[] = await this.dbm.execute(sql, params);
 
     return !!rows[0]?.approved;
   }
@@ -268,7 +337,7 @@ export class UserService extends BaseService {
    *
    * @returns All unapproved users.
    */
-  public async getUnapproved(): Promise<User[]> {
+  public async getUnapproved(): Promise<UnapprovedUsers[]> {
     const sql = `
       SELECT
         User.id AS userID, firstname, lastname, email, name AS status, joinTime
@@ -277,7 +346,7 @@ export class UserService extends BaseService {
       WHERE verified = TRUE AND approved = FALSE
       ORDER BY joinTime;
     `;
-    const rows: User[] = await this.dbm.execute(sql);
+    const rows: UnapprovedUsers[] = await this.dbm.execute(sql);
 
     return rows;
   }
@@ -291,7 +360,7 @@ export class UserService extends BaseService {
   public async isAdmin(userID: string): Promise<boolean> {
     const sql = `SELECT admin FROM User WHERE id = ?;`;
     const params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserAdmin[] = await this.dbm.execute(sql, params);
 
     return !!rows[0]?.admin;
   }
@@ -317,7 +386,7 @@ export class UserService extends BaseService {
   public async getUserImage(userID: string): Promise<Image> {
     const sql = `SELECT imageID from User WHERE id = ?;`;
     const params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserImageID[] = await this.dbm.execute(sql, params);
 
     const imageID = rows[0]?.imageID;
     const image = await this.dbm.imageService.getImage(imageID);
@@ -334,7 +403,7 @@ export class UserService extends BaseService {
   public async setUserImage(userID: string, imageData: Buffer): Promise<void> {
     let sql = `SELECT imageID from User WHERE id = ?;`;
     let params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserImageID[] = await this.dbm.execute(sql, params);
 
     const newImageID = await this.dbm.imageService.createImage(imageData);
 
@@ -354,7 +423,7 @@ export class UserService extends BaseService {
   public async deleteUserImage(userID: string): Promise<void> {
     let sql = `SELECT imageID from User WHERE id = ?;`;
     let params = [userID];
-    const rows: User[] = await this.dbm.execute(sql, params);
+    const rows: UserImageID[] = await this.dbm.execute(sql, params);
 
     sql = `UPDATE User SET imageID = ? WHERE id = ?`;
     params = [null, userID];

--- a/src/services/userStatus.ts
+++ b/src/services/userStatus.ts
@@ -14,6 +14,20 @@ export interface UserStatus {
 }
 
 /**
+ * User status with only ID architecture.
+ */
+interface UserStatusID {
+  id: number;
+}
+
+/**
+ * User status with only name architecture.
+ */
+interface UserStatusName {
+  name: string;
+}
+
+/**
  * User status services.
  */
 export class UserStatusService extends BaseService {
@@ -23,7 +37,7 @@ export class UserStatusService extends BaseService {
    * @returns A list of all user statuses.
    */
   public async getStatuses(): Promise<UserStatus[]> {
-    const sql = `SELECT id, name FROM UserStatus ORDER BY id;`;
+    const sql = `SELECT * FROM UserStatus ORDER BY id;`;
     const rows: UserStatus[] = await this.dbm.execute(sql);
 
     return rows;
@@ -38,7 +52,7 @@ export class UserStatusService extends BaseService {
   public async getStatusName(statusID: number): Promise<string> {
     const sql = `SELECT name FROM UserStatus WHERE id = ?;`;
     const params = [statusID];
-    const rows: UserStatus[] = await this.dbm.execute(sql, params);
+    const rows: UserStatusName[] = await this.dbm.execute(sql, params);
 
     return rows[0]?.name;
   }
@@ -52,7 +66,7 @@ export class UserStatusService extends BaseService {
   public async validStatus(statusID: number): Promise<boolean> {
     const sql = `SELECT id FROM UserStatus WHERE id = ?;`;
     const params = [statusID];
-    const rows: UserStatus[] = await this.dbm.execute(sql, params);
+    const rows: UserStatusID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }

--- a/src/services/userStatusChange.ts
+++ b/src/services/userStatusChange.ts
@@ -4,7 +4,6 @@
  */
 
 import { BaseService, getTime, newUniqueID } from "./util";
-import { User } from "./user";
 
 /**
  * User status change architecture.
@@ -14,6 +13,26 @@ export interface UserStatusChange {
   userID: string;
   newStatusID: number;
   createTime: number;
+}
+
+/**
+ * User statuus change with only ID architecture.
+ */
+interface UserStatusChangeID {
+  id: string;
+}
+
+/**
+ * User status change requests architecture.
+ */
+export interface UserStatusChangeRequest {
+  userID: string;
+  firstname: string;
+  lastname: string;
+  email: string;
+  status: string;
+  newStatus: string;
+  requestID: string;
 }
 
 /**
@@ -35,7 +54,7 @@ export class UserStatusChangeService extends BaseService {
 
     let sql = `SELECT id FROM UserStatusChange WHERE userID = ?;`;
     let params: any[] = [userID];
-    const rows: UserStatusChange[] = await this.dbm.execute(sql, params);
+    const rows: UserStatusChangeID[] = await this.dbm.execute(sql, params);
 
     if (rows.length === 0) {
       sql = `
@@ -67,7 +86,7 @@ export class UserStatusChangeService extends BaseService {
   public async statusChangeRequestExists(requestID: string): Promise<boolean> {
     const sql = `SELECT id FROM UserStatusChange WHERE id = ?;`;
     const params = [requestID];
-    const rows: UserStatusChange[] = await this.dbm.execute(sql, params);
+    const rows: UserStatusChangeID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }
@@ -112,7 +131,7 @@ export class UserStatusChangeService extends BaseService {
     return rows;
   }
 
-  public async getUserRequests(): Promise<User[]> {
+  public async getUserRequests(): Promise<UserStatusChangeRequest[]> {
     const sql = `
       SELECT
         User.id AS userID, firstname, lastname, email,
@@ -124,7 +143,7 @@ export class UserStatusChangeService extends BaseService {
       JOIN UserStatus AS us2 ON UserStatusChange.newStatusID = us2.id
       ORDER BY UserStatusChange.createTime;
     `;
-    const rows: User[] = await this.dbm.execute(sql);
+    const rows: UserStatusChangeRequest[] = await this.dbm.execute(sql);
 
     return rows;
   }

--- a/src/services/util.ts
+++ b/src/services/util.ts
@@ -6,10 +6,6 @@
 import DatabaseManager from "../services";
 import * as crypto from "crypto";
 import * as bcrypt from "bcrypt";
-import { Session } from "./session";
-import { Verify } from "./verify";
-import { PasswordReset } from "./passwordReset";
-import { Suspended } from "./suspended";
 import { metaConfig } from "../config";
 
 /**

--- a/src/services/util.ts
+++ b/src/services/util.ts
@@ -38,6 +38,51 @@ export const verifyIDLength = 16;
 export const passwordResetIDLength = 16;
 
 /**
+ * Table with a string ID field.
+ */
+interface TableStringID {
+  id: string;
+}
+
+/**
+ * Session with only update time architecture.
+ */
+interface SessionUpdateTime {
+  updateTime: number;
+}
+
+/**
+ * Session with only ID and update time architecture.
+ */
+interface SessionIDUpdateTime {
+  id: string;
+  updateTime: number;
+}
+
+/**
+ * Verify with only ID and create time architecture.
+ */
+interface VerifyIDCreateTime {
+  id: string;
+  createTime: number;
+}
+
+/**
+ * Password reset with only ID and create time architecture.
+ */
+interface PasswordResetIDCreateTime {
+  id: string;
+  createTime: number;
+}
+
+/**
+ * Suspended with only ID architecture.
+ */
+interface SuspendedID {
+  id: string;
+}
+
+/**
  * Base service class.
  */
 export abstract class BaseService {
@@ -119,7 +164,7 @@ export async function newUniqueID(
   let base64ID = await newID(len);
 
   const sql = `SELECT id FROM ${table} WHERE id = ?;`;
-  let rows = await dbm.execute(sql, [base64ID]);
+  let rows: TableStringID[] = await dbm.execute(sql, [base64ID]);
 
   while (rows.length > 0) {
     base64ID = await newID(len);
@@ -217,7 +262,7 @@ export async function pruneSession(
   setTimeout(async () => {
     let sql = `SELECT updateTime FROM Session WHERE id = ?;`;
     let params = [sessionID];
-    const rows: Session[] = await dbm.execute(sql, params);
+    const rows: SessionUpdateTime[] = await dbm.execute(sql, params);
 
     const updateTime = rows[0]?.updateTime;
     const deleteTime = updateTime + sessionAge / 1000;
@@ -238,7 +283,7 @@ export async function pruneSession(
 export async function pruneSessions(dbm: DatabaseManager): Promise<void> {
   const sql = `SELECT id, updateTime FROM Session;`;
   const params = [];
-  const rows: Session[] = await dbm.execute(sql, params);
+  const rows: SessionIDUpdateTime[] = await dbm.execute(sql, params);
 
   const sessionAge =
     (parseInt(await dbm.metaService.get("Session age")) ||
@@ -282,7 +327,7 @@ export async function pruneVerifyRecord(
 export async function pruneVerifyRecords(dbm: DatabaseManager): Promise<void> {
   const sql = `SELECT id, createTime FROM Verify;`;
   const params = [];
-  const rows: Verify[] = await dbm.execute(sql, params);
+  const rows: VerifyIDCreateTime[] = await dbm.execute(sql, params);
 
   const verifyAge =
     (parseInt(await dbm.metaService.get("Verify age")) ||
@@ -328,7 +373,7 @@ export async function prunePasswordResetRecords(
 ): Promise<void> {
   const sql = `SELECT id, createTime FROM PasswordReset;`;
   const params = [];
-  const rows: PasswordReset[] = await dbm.execute(sql, params);
+  const rows: PasswordResetIDCreateTime[] = await dbm.execute(sql, params);
 
   const passwordResetAge =
     (parseInt(await dbm.metaService.get("Password reset age")) ||
@@ -370,7 +415,7 @@ export async function pruneSuspension(
  */
 export async function pruneSuspensions(dbm: DatabaseManager): Promise<void> {
   const sql = `SELECT id FROM Suspended;`;
-  const rows: Suspended[] = await dbm.execute(sql);
+  const rows: SuspendedID[] = await dbm.execute(sql);
 
   rows.forEach((row) => {
     pruneSession(dbm, row.id);

--- a/src/services/verify.ts
+++ b/src/services/verify.ts
@@ -21,6 +21,13 @@ export interface Verify {
 }
 
 /**
+ * Verify with only ID architecture.
+ */
+interface VerifyID {
+  id: string;
+}
+
+/**
  * Verification services.
  */
 export class VerifyService extends BaseService {
@@ -45,7 +52,7 @@ export class VerifyService extends BaseService {
     // Check that no verification record has already been created
     let sql = `SELECT id FROM Verify WHERE email = ?;`;
     let params: any[] = [email];
-    let rows: Verify[] = await this.dbm.execute(sql, params);
+    let rows: VerifyID[] = await this.dbm.execute(sql, params);
 
     if (rows.length > 0) {
       return null;
@@ -80,7 +87,7 @@ export class VerifyService extends BaseService {
   public async verifyRecordExists(verifyID: string): Promise<boolean> {
     const sql = `SELECT id FROM Verify WHERE id = ?;`;
     const params = [verifyID];
-    const rows: Verify[] = await this.dbm.execute(sql, params);
+    const rows: VerifyID[] = await this.dbm.execute(sql, params);
 
     return rows.length > 0;
   }

--- a/test/services/post.test.ts
+++ b/test/services/post.test.ts
@@ -86,13 +86,13 @@ test("Post", async () => {
   let unapprovedPosts = await dbm.postService.getUnapproved();
   expect(unapprovedPosts.length).toBeGreaterThanOrEqual(1);
   const unapproved = getByProp(unapprovedPosts, "postID", postID);
-  expect(unapproved["postID"]).toBe(postID);
-  expect(unapproved["firstname"]).toBe(firstname);
-  expect(unapproved["lastname"]).toBe(lastname);
+  expect(unapproved.postID).toBe(postID);
+  expect(unapproved.firstname).toBe(firstname);
+  expect(unapproved.lastname).toBe(lastname);
   expect(unapproved.content).toBe(content);
   expect(unapproved.location).toBe(location);
-  expect(unapproved["locationType"]).toBe("Restaurant");
-  expect(unapproved["program"]).toBe(programName);
+  expect(unapproved.locationType).toBe("Restaurant");
+  expect(unapproved.program).toBe(programName);
   expect(unapproved.threeWords).toBe(threeWords);
   expect(unapproved.createTime - getTime()).toBeLessThanOrEqual(3);
 

--- a/test/services/query.test.ts
+++ b/test/services/query.test.ts
@@ -55,21 +55,21 @@ test("Query", async () => {
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Query by location
   results = await dbm.queryService.query("Location");
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Query by program
   results = await dbm.queryService.query("j-term");
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query by search string
   results = await dbm.queryService.advancedQuery(
@@ -79,7 +79,7 @@ test("Query", async () => {
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query by program
   results = await dbm.queryService.advancedQuery(
@@ -89,7 +89,7 @@ test("Query", async () => {
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query by location type
   results = await dbm.queryService.advancedQuery(
@@ -99,7 +99,7 @@ test("Query", async () => {
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query by user status
   results = await dbm.queryService.advancedQuery(
@@ -109,7 +109,7 @@ test("Query", async () => {
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query by rating
   results = await dbm.queryService.advancedQuery(
@@ -119,53 +119,53 @@ test("Query", async () => {
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query sort by program
   results = await dbm.queryService.advancedQuery({}, "program");
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query sort by location type
   results = await dbm.queryService.advancedQuery({}, "locationType");
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query sort by user status
   results = await dbm.queryService.advancedQuery({}, "userStatus");
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query sort by rating
   results = await dbm.queryService.advancedQuery({}, "rating");
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query sort by timestamp
   results = await dbm.queryService.advancedQuery({}, "timestamp");
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
 
   // Advanced query sort by rating descending
   results = await dbm.queryService.advancedQuery({}, "rating", false);
   expect(results.length).toBeGreaterThan(0);
   result = getByID(results, postID);
   expect(result?.id).toBe(postID);
-  expect(result["rating"]).toBe(generalRating);
+  expect(result.rating).toBe(generalRating);
   let lastRating = 5;
   for (const res of results) {
-    expect(res["rating"]).toBeLessThanOrEqual(lastRating);
-    lastRating = res["rating"];
+    expect(res.rating).toBeLessThanOrEqual(lastRating);
+    lastRating = res.rating;
   }
 
   // Advanced query with empty list

--- a/test/services/user.test.ts
+++ b/test/services/user.test.ts
@@ -74,11 +74,11 @@ test("User", async () => {
   let unapproved = await dbm.userService.getUnapproved();
   expect(unapproved.length).toBeGreaterThanOrEqual(1);
   const unapprovedUser = getByProp(unapproved, "userID", userID);
-  expect(unapprovedUser["userID"]).toBe(userID);
+  expect(unapprovedUser.userID).toBe(userID);
   expect(unapprovedUser.firstname).toBe(firstname);
   expect(unapprovedUser.lastname).toBe(lastname);
   expect(unapprovedUser.email).toBe(email);
-  expect(unapprovedUser["status"]).toBe("Student");
+  expect(unapprovedUser.status).toBe("Student");
   expect(unapprovedUser.joinTime - getTime()).toBeLessThanOrEqual(3);
 
   // Log user in

--- a/test/services/userStatusChange.test.ts
+++ b/test/services/userStatusChange.test.ts
@@ -83,13 +83,13 @@ test("UserStatusChange", async () => {
   const userRequests = await dbm.userStatusChangeService.getUserRequests();
   expect(userRequests.length).toBeGreaterThanOrEqual(1);
   const userRequest = getByProp(userRequests, "requestID", requestID);
-  expect(userRequest["userID"]).toBe(userID);
+  expect(userRequest.userID).toBe(userID);
   expect(userRequest.firstname).toBe(firstname);
   expect(userRequest.lastname).toBe(lastname);
   expect(userRequest.email).toBe(email);
-  expect(userRequest["status"]).toBe("Student");
-  expect(userRequest["newStatus"]).toBe("Alum");
-  expect(userRequest["requestID"]).toBe(requestID);
+  expect(userRequest.status).toBe("Student");
+  expect(userRequest.newStatus).toBe("Alum");
+  expect(userRequest.requestID).toBe(requestID);
 
   // Create new post
   const content = "Post content";


### PR DESCRIPTION
This PR improves the return types used in the service layer. Previously, loose types were used, especially in advanced queries merging multiple tables. Strict interface types are now being used.