### PR TITLE
Improve admin heart change time

### DIFF
--- a/src/static/js/admin-stats.js
+++ b/src/static/js/admin-stats.js
@@ -65,14 +65,7 @@ function toggleFavoritePost(postID) {
     data: {
       postID,
     },
-    success: (favString) => {
-      const favorited = favString === "true" ? true : false;
-      if (favorited) {
-        $(`#favorite-${postID}`).removeClass("far").addClass("fas");
-      } else {
-        $(`#favorite-${postID}`).removeClass("fas").addClass("far");
-      }
-
+    success: () => {
       hideError();
       updateNotifications();
       populateStats();
@@ -83,6 +76,16 @@ function toggleFavoritePost(postID) {
       showError("Failed to favorite post");
     },
   });
+}
+
+// Toggle favorite heart icon
+function toggleFavoriteHeart(postID) {
+  const favorited = $(`#favorite-${postID}.fas`).length === 0;
+  if (favorited) {
+    $(`#favorite-${postID}`).removeClass("far").addClass("fas");
+  } else {
+    $(`#favorite-${postID}`).removeClass("fas").addClass("far");
+  }
 }
 
 // Create a row in the users table
@@ -159,6 +162,7 @@ function createPostRow(post) {
     )
     .click(() => {
       toggleFavoritePost(post.postID);
+      toggleFavoriteHeart(post.postID);
     });
   const favoriteButton = newElement("td").append(favoriteHeart);
   const deletePostButton = newElement("button")


### PR DESCRIPTION
The admin favorite heart used to update when the API call to favorite/unfavorite the post returned successfully. Now, to make things appear seamless, it updates immediately upon clicking the icon.