### PR TITLE
Show no search results message

### DIFF
--- a/src/views/query.html
+++ b/src/views/query.html
@@ -153,13 +153,15 @@
 
   <div id="query-page">
     <div class="row">
-      {{#each posts}}
+      {{#if posts}} {{#each posts}}
       <a href="/post/{{this.id}}" class="a-location col-12 col-sm-6 col-lg-4">
         <img src="/image/post/{{this.id}}/0" alt="{{this.location}}" /><span
           >{{this.location}}</span
         >
       </a>
-      {{/each}}
+      {{/each}} {{else}}
+      <div class="text-center div-center">No search results</div>
+      {{/if}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
When no posts are returned on the query page, a "No search results" message is shown to indicate to users that they are using the application correctly.